### PR TITLE
feat: add regex filtering support for config adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ console.log(config.host)
 
 #### Env Adapter
 
-Loads the configuration from `process.env` or a custom object, allowing filtering the prefix keys to load.
+Loads the configuration from `process.env` or a custom object, allowing filtering the keys using a regex.
 
 ```ts
 import { z } from 'zod';
@@ -114,11 +114,11 @@ const config = await loadConfig({
   adapters: envAdapter(),
 });
 
-// using custom env + filter prefix key
+// using custom env + filter regex
 const customConfig = await loadConfig({
   schema: schemaConfig,
   adapters: envAdapter({ 
-    prefixKey: 'MY_APP_',
+    regex: /^MY_APP_/,
     customEnv: {
       MY_APP_PORT: '3000',
       MY_APP_HOST: 'localhost',
@@ -148,12 +148,12 @@ const config = await loadConfig({
   adapters: jsonAdapter({ path: filePath }),
 });
 
-// using filter prefix key
+// using filter regex
 const customConfig = await loadConfig({
   schema: schemaConfig,
   adapters: jsonAdapter({ 
     path: filePath,
-    prefixKey: 'MY_APP_',
+    regex: /^MY_APP_/,
   }),
 });
 ```
@@ -183,12 +183,12 @@ const config = await loadConfig({
   adapters: yamlAdapter({ path: filePath }),
 });
 
-// using filter prefix key
+// using filter regex
 const customConfig = await loadConfig({
   schema: schemaConfig,
   adapters: yamlAdapter({ 
     path: filePath,
-    prefixKey: 'MY_APP_',
+    regex: /^MY_APP_/,
   }),
 });
 ```
@@ -218,12 +218,12 @@ const config = await loadConfig({
   adapters: tomlAdapter({ path: filePath }),
 });
 
-// using filter prefix key
+// using filter regex
 const customConfig = await loadConfig({
   schema: schemaConfig,
   adapters: tomlAdapter({ 
     path: filePath,
-    prefixKey: 'MY_APP_',
+    regex: /^MY_APP_/,
   }),
 });
 ```
@@ -253,12 +253,12 @@ const config = await loadConfig({
   adapters: dotEnvAdapter({ path: filePath }),
 });
 
-// using filter prefix key
+// using filter regex
 const customConfig = await loadConfig({
   schema: schemaConfig,
   adapters: dotEnvAdapter({ 
     path: filePath,
-    prefixKey: 'MY_APP_',
+    regex: /^MY_APP_/,
   }),
 });
 ```

--- a/src/lib/adapters/dotenv-adapter/index.ts
+++ b/src/lib/adapters/dotenv-adapter/index.ts
@@ -1,17 +1,15 @@
 import { parse } from "dotenv";
 import { readFile } from "node:fs/promises";
-import type { Adapter } from "../../../types";
-import { filterByPrefixKey } from "../utils";
+import type { Adapter, BaseAdapterProps } from "../../../types";
+import { filteredData } from "../utils";
 
-export type DotEnvAdapterProps = {
+export type DotEnvAdapterProps = BaseAdapterProps & {
   path: string;
-  prefixKey?: string;
-  silent?: boolean;
 };
 
 const ADAPTER_NAME = "dotenv adapter";
 
-export const dotEnvAdapter = ({ path, prefixKey, silent }: DotEnvAdapterProps): Adapter => {
+export const dotEnvAdapter = ({ path, prefixKey, regex, silent }: DotEnvAdapterProps): Adapter => {
   return {
     name: ADAPTER_NAME,
     read: async () => {
@@ -20,11 +18,7 @@ export const dotEnvAdapter = ({ path, prefixKey, silent }: DotEnvAdapterProps): 
 
         const parsedData = parse(data) || {};
 
-        if (prefixKey) {
-          return filterByPrefixKey(parsedData, prefixKey);
-        }
-
-        return parsedData;
+        return filteredData(parsedData, { prefixKey, regex });
       } catch (error) {
         throw new Error(
           `Failed to parse / read .env file at ${path}: ${

--- a/src/lib/adapters/env-adapter/index.ts
+++ b/src/lib/adapters/env-adapter/index.ts
@@ -1,25 +1,24 @@
-import type { Adapter } from "../../../types";
-import { filterByPrefixKey } from "../utils";
+import type { Adapter, BaseAdapterProps } from "../../../types";
+import { filteredData } from "../utils";
 
-export type EnvAdapterProps = {
+export type EnvAdapterProps = BaseAdapterProps & {
   customEnv?: Record<string, any>;
-  prefixKey?: string;
-  silent?: boolean;
 };
 
 const ADAPTER_NAME = "env adapter";
 
-export const envAdapter = ({ customEnv, prefixKey, silent }: EnvAdapterProps = {}): Adapter => {
+export const envAdapter = ({
+  customEnv,
+  prefixKey,
+  regex,
+  silent,
+}: EnvAdapterProps = {}): Adapter => {
   return {
     name: ADAPTER_NAME,
     read: async () => {
       const data = customEnv || process.env || {};
 
-      if (prefixKey) {
-        return filterByPrefixKey(data, prefixKey);
-      }
-
-      return data;
+      return filteredData(data, { prefixKey, regex });
     },
     silent,
   };

--- a/src/lib/adapters/json-adapter/index.ts
+++ b/src/lib/adapters/json-adapter/index.ts
@@ -1,16 +1,14 @@
-import type { Adapter } from "../../../types";
-import { filterByPrefixKey } from "../utils";
+import type { Adapter, BaseAdapterProps } from "../../../types";
+import { filteredData } from "../utils";
 import { readFile } from "node:fs/promises";
 
-export type JsonAdapterProps = {
+export type JsonAdapterProps = BaseAdapterProps & {
   path: string;
-  prefixKey?: string;
-  silent?: boolean;
 };
 
 const ADAPTER_NAME = "json adapter";
 
-export const jsonAdapter = ({ path, prefixKey, silent }: JsonAdapterProps): Adapter => {
+export const jsonAdapter = ({ path, prefixKey, regex, silent }: JsonAdapterProps): Adapter => {
   return {
     name: ADAPTER_NAME,
     read: async () => {
@@ -19,11 +17,7 @@ export const jsonAdapter = ({ path, prefixKey, silent }: JsonAdapterProps): Adap
 
         const parsedData = JSON.parse(data) || {};
 
-        if (prefixKey) {
-          return filterByPrefixKey(parsedData, prefixKey);
-        }
-
-        return parsedData;
+        return filteredData(parsedData, { prefixKey, regex });
       } catch (error) {
         throw new Error(
           `Failed to parse / read JSON file at ${path}: ${

--- a/src/lib/adapters/script-adapter/index.ts
+++ b/src/lib/adapters/script-adapter/index.ts
@@ -1,26 +1,20 @@
-import type { Adapter } from "../../../types";
-import { filterByPrefixKey } from "../utils";
+import type { Adapter, BaseAdapterProps } from "../../../types";
+import { filteredData } from "../utils";
 
-export type ScriptAdapterProps = {
+export type ScriptAdapterProps = BaseAdapterProps & {
   path: string;
-  prefixKey?: string;
-  silent?: boolean;
 };
 
 const ADAPTER_NAME = "script adapter";
 
-export const scriptAdapter = ({ path, prefixKey, silent }: ScriptAdapterProps): Adapter => {
+export const scriptAdapter = ({ path, prefixKey, regex, silent }: ScriptAdapterProps): Adapter => {
   return {
     name: ADAPTER_NAME,
     read: async () => {
       try {
         const { default: data } = await import(path);
 
-        if (prefixKey) {
-          return filterByPrefixKey(data, prefixKey);
-        }
-
-        return data;
+        return filteredData(data, { prefixKey, regex });
       } catch (error) {
         throw new Error(
           `Failed to import() script at ${path}: ${error instanceof Error ? error.message : error}`,

--- a/src/lib/adapters/toml-adapter/index.ts
+++ b/src/lib/adapters/toml-adapter/index.ts
@@ -1,16 +1,14 @@
-import type { Adapter } from "../../../types";
-import { filterByPrefixKey } from "../utils";
+import type { Adapter, BaseAdapterProps } from "../../../types";
+import { filteredData } from "../utils";
 import { readFile } from "node:fs/promises";
 import { parse as tomlParse } from "smol-toml";
 
-export type TomlAdapterProps = {
+export type TomlAdapterProps = BaseAdapterProps & {
   path: string;
-  prefixKey?: string;
-  silent?: boolean;
 };
 const ADAPTER_NAME = "toml adapter";
 
-export const tomlAdapter = ({ path, prefixKey, silent }: TomlAdapterProps): Adapter => {
+export const tomlAdapter = ({ path, prefixKey, regex, silent }: TomlAdapterProps): Adapter => {
   return {
     name: ADAPTER_NAME,
     read: async () => {
@@ -19,11 +17,7 @@ export const tomlAdapter = ({ path, prefixKey, silent }: TomlAdapterProps): Adap
 
         const parsedData = tomlParse(data) || {};
 
-        if (prefixKey) {
-          return filterByPrefixKey(parsedData, prefixKey);
-        }
-
-        return parsedData;
+        return filteredData(parsedData, { prefixKey, regex });
       } catch (error) {
         throw new Error(
           `Failed to parse / read TOML file at ${path}: ${

--- a/src/lib/adapters/yaml-adapter/index.ts
+++ b/src/lib/adapters/yaml-adapter/index.ts
@@ -1,17 +1,15 @@
-import type { Adapter } from "../../../types";
-import { filterByPrefixKey } from "../utils";
+import type { Adapter, BaseAdapterProps } from "../../../types";
+import { filteredData } from "../utils";
 import { readFile } from "node:fs/promises";
 import YAML from "yaml";
 
-export type YamlAdapterProps = {
+export type YamlAdapterProps = BaseAdapterProps & {
   path: string;
-  prefixKey?: string;
-  silent?: boolean;
 };
 
 const ADAPTER_NAME = "yaml adapter";
 
-export const yamlAdapter = ({ path, prefixKey, silent }: YamlAdapterProps): Adapter => {
+export const yamlAdapter = ({ path, prefixKey, regex, silent }: YamlAdapterProps): Adapter => {
   return {
     name: ADAPTER_NAME,
     read: async () => {
@@ -20,11 +18,7 @@ export const yamlAdapter = ({ path, prefixKey, silent }: YamlAdapterProps): Adap
 
         const parsedData = YAML.parse(data) || {};
 
-        if (prefixKey) {
-          return filterByPrefixKey(parsedData, prefixKey);
-        }
-
-        return parsedData;
+        return filteredData(parsedData, { prefixKey, regex });
       } catch (error) {
         throw new Error(
           `Failed to parse / read YAML file at ${path}: ${

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,19 +1,74 @@
 import type { z } from "zod";
 
-export type Adapter = {
+/**
+ * Adapter type
+ */
+export type Adapter<T extends z.AnyZodObject = z.AnyZodObject> = {
+  /**
+   * Name of the adapter
+   */
   name: string;
-  read: () => Promise<z.infer<z.AnyZodObject>>;
+  /**
+   * Read the config
+   */
+  read: () => Promise<z.infer<T>>;
+  /**
+   * Whether to suppress errors
+   */
   silent?: boolean;
 };
 
+/**
+ * Config type
+ */
 export type Config<T extends z.AnyZodObject = z.AnyZodObject> = {
+  /**
+   * Schema to validate the config against
+   */
   schema: T;
+  /**
+   * Adapters to use
+   */
   adapters?: Adapter[] | Adapter;
+  /**
+   * Function to call on success
+   */
   onSuccess?: (data: z.infer<T>) => void;
+  /**
+   * Function to call on error
+   */
   onError?: (error: z.ZodError<z.infer<T>>) => void;
+  /**
+   * Logger to use
+   */
   logger?: Logger;
 };
 
+/**
+ * Logger type
+ */
 export type Logger = {
+  /**
+   * Log a warning
+   */
   warn: (message: string) => void;
+};
+
+/**
+ * Base adapter props
+ */
+export type BaseAdapterProps = {
+  /**
+   * Prefix key to filter keys by
+   * @deprecated Use regex instead
+   */
+  prefixKey?: string;
+  /**
+   * Regular expression to filter keys by: if used, prefixKey will be ignored
+   */
+  regex?: RegExp;
+  /**
+   * Whether to suppress errors
+   */
+  silent?: boolean;
 };

--- a/tests/dotenv-adapter.test.ts
+++ b/tests/dotenv-adapter.test.ts
@@ -36,6 +36,26 @@ describe("dotenv adapter", () => {
     expect(config.HOST).toBe("localhost");
     expect(config.PORT).toBe("3000");
   });
+  it("should return parsed data when schema is valid with regex key", async () => {
+    // given
+    const schema = z.object({
+      HOST: z.string(),
+    });
+
+    // when
+    const config = await loadConfig({
+      schema,
+      adapters: dotEnvAdapter({
+        path: testFilePath,
+        regex: /^HOST$/,
+      }),
+    });
+
+    // then
+    expect(config).toEqual({
+      HOST: "localhost",
+    });
+  });
   it("should throw zod error when schema is invalid", async () => {
     // given
     const schema = z.object({

--- a/tests/env-adapter.test.ts
+++ b/tests/env-adapter.test.ts
@@ -50,4 +50,28 @@ describe("env adapter", () => {
     expect(config.APP_NAME).toBe("app name");
     expect(config.PORT).toBe("3000");
   });
+  it("should return parsed data when schema is valid with regex key", async () => {
+    // given
+    const schema = z.object({
+      APP_NAME: z.string(),
+    });
+
+    process.env = {
+      APP_NAME: "app name",
+      PORT: "3000",
+    };
+
+    // when
+    const config = await loadConfig({
+      schema,
+      adapters: envAdapter({
+        regex: /^APP_/,
+      }),
+    });
+
+    // then
+    expect(config).toEqual({
+      APP_NAME: "app name",
+    });
+  });
 });

--- a/tests/script-adapter.test.ts
+++ b/tests/script-adapter.test.ts
@@ -78,10 +78,7 @@ describe("combining multiple script adapters", () => {
   });
 
   afterAll(async () => {
-    await Promise.all([
-      unlink(testFilePath1),
-      unlink(testFilePath2),
-    ]);
+    await Promise.all([unlink(testFilePath1), unlink(testFilePath2)]);
   });
 
   it("should successfully parse, merge and return type-safe data", async () => {
@@ -91,7 +88,7 @@ describe("combining multiple script adapters", () => {
       PORT: z.string().regex(/^\d+$/),
       TEST_RECORD: z.object({
         key: z.string(),
-        value: z.string()
+        value: z.string(),
       }),
       TEST_MAP: z.map(z.string(), z.string()).optional(),
     });
@@ -99,19 +96,16 @@ describe("combining multiple script adapters", () => {
     // when
     const config = await loadConfig({
       schema,
-      adapters: [
-        scriptAdapter({ path: testFilePath1 }),
-        scriptAdapter({ path: testFilePath2 }),
-      ],
+      adapters: [scriptAdapter({ path: testFilePath1 }), scriptAdapter({ path: testFilePath2 })],
     });
 
     // then
     expect(config.HOST).toBe("app name2"); // second adapter overrides the first one
     expect(config.PORT).toBe("1234"); // second adapter overrides the first one
     expect(config.TEST_MAP).toEqual(new Map([["key", "value2"]])); // MAP is not mergeable so only the last one is loaded
-    expect(config.TEST_RECORD).toEqual({ 
-      key: "key2",    // from second adapter
-      value: "value1" // preserved from first adapter
+    expect(config.TEST_RECORD).toEqual({
+      key: "key2", // from second adapter
+      value: "value1", // preserved from first adapter
     }); // records are merged between adapters
   });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,81 @@
-import { deepMerge, filterByPrefixKey, isMergeableObject } from "../src/lib/adapters/utils";
+import {
+  deepMerge,
+  filterByPrefixKey,
+  filterByRegex,
+  isMergeableObject,
+} from "../src/lib/adapters/utils";
 import { describe, it, expect } from "vitest";
+
+describe("filterByRegex", () => {
+  it("should return an object with keys that match the regex #1", () => {
+    // given
+    const data = {
+      APP_NAME: "my-app",
+      TEST_NAME: "my-test",
+    };
+
+    // starts with TEST_
+    const regex = /^TEST_/;
+
+    // when
+    const filteredData = filterByRegex(data, regex);
+
+    // then
+    expect(filteredData).toEqual({
+      TEST_NAME: "my-test",
+    });
+  });
+  it("should return an object with keys that match the regex #2", () => {
+    // given
+    const data = {
+      REACT_APP_NAME: "my-app",
+      REACT_APP_TEST_NAME: "my-test",
+      APP_NAME: "my-app",
+      TEST_APP: "my-test",
+    };
+
+    // contains _APP_ in the middle of the key
+    const regex = /_APP_/;
+
+    // when
+    const filteredData = filterByRegex(data, regex);
+
+    // then
+    expect(filteredData).toEqual({
+      REACT_APP_NAME: "my-app",
+      REACT_APP_TEST_NAME: "my-test",
+    });
+  });
+
+  it("should return an empty object if no keys match the regex", () => {
+    // given
+    const data = {
+      APP_NAME: "my-app",
+      TEST_NAME: "my-test",
+    };
+
+    // no keys match the regex
+    const regex = /NOT_MATCHING/;
+
+    // when
+    const filteredData = filterByRegex(data, regex);
+
+    // then
+    expect(filteredData).toEqual({});
+  });
+
+  it("should return an empty object if the input object is empty", () => {
+    // given
+    const data = {};
+    const regex = /NOT_MATCHING/;
+
+    // when
+    const filteredData = filterByRegex(data, regex);
+
+    // then
+    expect(filteredData).toEqual({});
+  });
+});
 
 describe("filterByPrefixKey", () => {
   it("should return an object with keys that start with the prefix", () => {
@@ -87,7 +163,7 @@ describe("deepMerge", () => {
     expect(result).toEqual({ a: 1, b: 2, c: [] });
   });
   it("should override with null values", () => {
-    const obj1 = { a: 1, b: 2 }; 
+    const obj1 = { a: 1, b: 2 };
     const obj2 = { a: null, c: [] };
     const result = deepMerge(obj1, obj2);
     expect(result).toEqual({ a: null, b: 2, c: [] });


### PR DESCRIPTION
- Introduce `BaseAdapterProps` with optional `regex` parameter
- Add `filterByRegex` utility function to filter config keys
- Create `filteredData` utility function to handle both prefix and regex filtering
- Update all adapters to support regex-based key filtering
- Add comprehensive tests for regex filtering
- Deprecate `prefixKey` in favor of more flexible regex filtering