### PR TITLE
feat: add loadConfigSync method

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ yarn add zod-config zod # yarn
 
 ## Quick Start
 
-Zod Config provides a `loadConfig` function that takes a Zod Object schema and returns a promise that resolves to the configuration object - it supports both asynchronous and synchronous adapters / Zod schemas. The library also provides a `loadConfigSync` function version which takes the same configuration, but does not return a Promise anymore (note that you cannot provide asynchronous adapters or Zod schemas to `loadConfigSync`, see [Synchronous loading](#synchronous-loading) for more information).
+Zod Config provides a `loadConfig` function that takes a Zod Object schema and returns a promise that resolves to the configuration object - it supports both asynchronous and synchronous adapters / Zod schemas. The library also provides a `loadConfigSync` function version which takes the same configuration, but does not return a Promise anymore (note that you cannot provide asynchronous adapters / Zod schemas to `loadConfigSync`, see [Synchronous loading](#synchronous-loading) for more information).
 
 Here are the available configuration options:
 

--- a/README.md
+++ b/README.md
@@ -60,20 +60,20 @@ yarn add zod-config zod # yarn
 
 ## Quick Start
 
-Zod Config provides a `loadConfig` function that takes a Zod Object schema and returns a promise that resolves to the configuration object.
+Zod Config provides a `loadConfig` function that takes a Zod Object schema and returns a promise that resolves to the configuration object - it supports both asynchronous and synchronous adapters / Zod schemas. The library also provides a `loadConfigSync` function version which takes the same configuration, but does not return a Promise anymore (note that you cannot provide asynchronous adapters or Zod schemas to `loadConfigSync`, see [Synchronous loading](#synchronous-loading) for more information).
+
+Here are the available configuration options:
 
 | Property | Type | Description | Required |
 | --- | --- | --- | --- |
 | `schema` | `AnyZodObject` | A Zod Object schema to validate the configuration. | `true` |
-| `adapters` | `Array<Adapter | SyncAdapter> or Adapter or SyncAdapter` | Adapter(s) to load the configuration from. If not provided, process.env will be used. | `false` |
+| `adapters` | `Array<Adapter \| SyncAdapter> \| Adapter \| SyncAdapter` | Adapter(s) to load the configuration from. If not provided, process.env will be used. | `false` |
 | `onError` | `(error: Error) => void` | A callback to be called when an error occurs. | `false` |
 | `onSuccess` | `(config: z.infer ) => void` | A callback to be called when the configuration is loaded successfully. | `false` |
 | `logger` | `Logger` | A custom logger to be used to log messages. By default, it uses `console`. | `false` |
 | `keyMatching` | `'strict'` / `'lenient'` | How to match keys between the schema and the data of the adapters. By default, it uses `strict`. | `false` |
 
-From the package we also expose the types `Adapter`, `SyncAdapter`, `Config`, `SyncConfig` and `Logger` in case you want to use them in your own adapters.
-
-The library also provides a `loadConfigSync` function which takes the same configuration, but does not return a Promise. You cannot provide asynchronous adapters or Zod schemas to `loadConfigSync`. See [Synchronous loading](#synchronous-loading) for more information.
+From the package we also expose the necessary types in case you want to use them in your own adapters.
 
 This library provides some built in adapters to load the configuration from different sources via modules. You can easily import them from `zod-config/<built-in-adapter-module-name>` (see the examples below).
 
@@ -130,7 +130,7 @@ console.log(config.host)
 
 #### Env Adapter
 
-Loads the configuration from `process.env` or a custom object, allowing filtering the keys using a regex.
+Loads the configuration from `process.env` or a custom object, allowing you to filter the keys using a regex (this can be useful when you have multiple adapters and you want to filter the keys to avoid conflicts or just to keep only the keys you need to process - it is also available in some other built-in adapter).
 
 ```ts
 import { z } from 'zod';

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ yarn add zod-config zod # yarn
   - [Script Adapter](#script-adapter)
   - [Directory Adapter](#directory-adapter)
 - [Combine multiple adapters](#combine-multiple-adapters)
+- [Synchronous loading](#synchronous-loading)
 - [Callbacks](#callbacks)
 - [Custom Logger](#custom-logger)
 - [Silent mode](#silent-mode)
@@ -64,13 +65,15 @@ Zod Config provides a `loadConfig` function that takes a Zod Object schema and r
 | Property | Type | Description | Required |
 | --- | --- | --- | --- |
 | `schema` | `AnyZodObject` | A Zod Object schema to validate the configuration. | `true` |
-| `adapters` | `Adapter[] or Adapter` | Adapter(s) to load the configuration from. If not provided, process.env will be used. | `false` |
+| `adapters` | `Array<Adapter | SyncAdapter> or Adapter or SyncAdapter` | Adapter(s) to load the configuration from. If not provided, process.env will be used. | `false` |
 | `onError` | `(error: Error) => void` | A callback to be called when an error occurs. | `false` |
 | `onSuccess` | `(config: z.infer ) => void` | A callback to be called when the configuration is loaded successfully. | `false` |
 | `logger` | `Logger` | A custom logger to be used to log messages. By default, it uses `console`. | `false` |
 | `keyMatching` | `'strict'` / `'lenient'` | How to match keys between the schema and the data of the adapters. By default, it uses `strict`. | `false` |
 
-From the package we also expose the types `Adapter`, `Config` and `Logger` in case you want to use them in your own adapters.
+From the package we also expose the types `Adapter`, `SyncAdapter`, `Config`, `SyncConfig` and `Logger` in case you want to use them in your own adapters.
+
+The library also provides a `loadConfigSync` function which takes the same configuration, but does not return a Promise. You cannot provide asynchronous adapters or Zod schemas to `loadConfigSync`. See [Synchronous loading](#synchronous-loading) for more information.
 
 This library provides some built in adapters to load the configuration from different sources via modules. You can easily import them from `zod-config/<built-in-adapter-module-name>` (see the examples below).
 
@@ -400,6 +403,41 @@ const schemaConfig = z.object({
 const filePath = path.join(__dirname, 'config.json');
 
 const config = await loadConfig({
+  schema: schemaConfig,
+  adapters: [
+    jsonAdapter({ path: filePath }),
+    envAdapter(),
+  ],
+});
+```
+
+### Synchronous loading
+
+The `loadConfig` function is asynchronous to allow for adapters that are asynchronous. If you are only using synchronous adapters, you can use the `loadConfigSync` function which is synchronous and does not return a promise.
+
+The following default adapters are synchronous and can be used with `loadConfigSync`:
+- `envAdapter`
+- `jsonAdapter`
+- `yamlAdapter`
+- `tomlAdapter`
+- `dotEnvAdapter`
+
+When implementing a custom adapter that you want to use with `loadConfigSync`, make sure to implement the `SyncAdapter` interface instead of the `Adapter` interface.
+
+```ts
+import { z } from 'zod';
+import { loadConfigSync } from 'zod-config';
+import { envAdapter } from 'zod-config/env-adapter';
+import { jsonAdapter } from 'zod-config/json-adapter';
+
+const schemaConfig = z.object({
+  port: z.string().regex(/^\d+$/),
+  host: z.string(),
+});
+
+const filePath = path.join(__dirname, 'config.json');
+
+const config = loadConfigSync({
   schema: schemaConfig,
   adapters: [
     jsonAdapter({ path: filePath }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
-export type { Adapter, Config, Logger } from "./types";
+export type { Adapter, SyncAdapter, Config, SyncConfig, Logger } from "./types";
 export { loadConfig } from "./lib/config";
+export { loadConfigSync } from "./lib/configSync";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export type { Adapter, SyncAdapter, Config, SyncConfig, Logger } from "./types";
 export { loadConfig } from "./lib/config";
-export { loadConfigSync } from "./lib/configSync";
+export { loadConfigSync } from "./lib/config-sync";

--- a/src/lib/adapters/dotenv-adapter/index.ts
+++ b/src/lib/adapters/dotenv-adapter/index.ts
@@ -1,7 +1,7 @@
 import { parse } from "dotenv";
-import { readFile } from "node:fs/promises";
-import type { Adapter, BaseAdapterProps } from "../../../types";
+import type { SyncAdapter, BaseAdapterProps } from "../../../types";
 import { filteredData } from "../../utils";
+import { readFileSync } from "node:fs";
 
 export type DotEnvAdapterProps = BaseAdapterProps & {
   path: string;
@@ -9,12 +9,12 @@ export type DotEnvAdapterProps = BaseAdapterProps & {
 
 const ADAPTER_NAME = "dotenv adapter";
 
-export const dotEnvAdapter = ({ path, regex, silent }: DotEnvAdapterProps): Adapter => {
+export const dotEnvAdapter = ({ path, regex, silent }: DotEnvAdapterProps): SyncAdapter => {
   return {
     name: ADAPTER_NAME,
-    read: async () => {
+    read: () => {
       try {
-        const data = await readFile(path, "utf-8");
+        const data = readFileSync(path, "utf-8");
 
         const parsedData = parse(data) || {};
 

--- a/src/lib/adapters/env-adapter/index.ts
+++ b/src/lib/adapters/env-adapter/index.ts
@@ -1,5 +1,5 @@
 import { getSafeProcessEnv } from "@/lib/utils/get-safe-process-env";
-import type { Adapter, BaseAdapterProps } from "../../../types";
+import type { BaseAdapterProps, SyncAdapter } from "../../../types";
 import { filteredData } from "../../utils";
 
 export type EnvAdapterProps = BaseAdapterProps & {
@@ -8,10 +8,10 @@ export type EnvAdapterProps = BaseAdapterProps & {
 
 const ADAPTER_NAME = "env adapter";
 
-export const envAdapter = ({ customEnv, regex, silent }: EnvAdapterProps = {}): Adapter => {
+export const envAdapter = ({ customEnv, regex, silent }: EnvAdapterProps = {}): SyncAdapter => {
   return {
     name: ADAPTER_NAME,
-    read: async () => {
+    read: () => {
       const data = customEnv || getSafeProcessEnv();
 
       return filteredData(data, { regex });

--- a/src/lib/adapters/json-adapter/index.ts
+++ b/src/lib/adapters/json-adapter/index.ts
@@ -1,6 +1,6 @@
-import type { Adapter, BaseAdapterProps } from "../../../types";
+import { readFileSync } from "node:fs";
+import type { BaseAdapterProps, SyncAdapter } from "../../../types";
 import { filteredData } from "../../utils";
-import { readFile } from "node:fs/promises";
 
 export type JsonAdapterProps = BaseAdapterProps & {
   path: string;
@@ -8,12 +8,12 @@ export type JsonAdapterProps = BaseAdapterProps & {
 
 const ADAPTER_NAME = "json adapter";
 
-export const jsonAdapter = ({ path, regex, silent }: JsonAdapterProps): Adapter => {
+export const jsonAdapter = ({ path, regex, silent }: JsonAdapterProps): SyncAdapter => {
   return {
     name: ADAPTER_NAME,
-    read: async () => {
+    read: () => {
       try {
-        const data = await readFile(path, "utf-8");
+        const data = readFileSync(path, "utf-8");
 
         const parsedData = JSON.parse(data) || {};
 

--- a/src/lib/adapters/toml-adapter/index.ts
+++ b/src/lib/adapters/toml-adapter/index.ts
@@ -1,6 +1,6 @@
-import type { Adapter, BaseAdapterProps } from "../../../types";
+import { readFileSync } from "node:fs";
+import type { BaseAdapterProps, SyncAdapter } from "../../../types";
 import { filteredData } from "../../utils";
-import { readFile } from "node:fs/promises";
 import { parse as tomlParse } from "smol-toml";
 
 export type TomlAdapterProps = BaseAdapterProps & {
@@ -8,12 +8,12 @@ export type TomlAdapterProps = BaseAdapterProps & {
 };
 const ADAPTER_NAME = "toml adapter";
 
-export const tomlAdapter = ({ path, regex, silent }: TomlAdapterProps): Adapter => {
+export const tomlAdapter = ({ path, regex, silent }: TomlAdapterProps): SyncAdapter => {
   return {
     name: ADAPTER_NAME,
-    read: async () => {
+    read: () => {
       try {
-        const data = await readFile(path, "utf-8");
+        const data = readFileSync(path, "utf-8");
 
         const parsedData = tomlParse(data) || {};
 

--- a/src/lib/adapters/yaml-adapter/index.ts
+++ b/src/lib/adapters/yaml-adapter/index.ts
@@ -1,6 +1,6 @@
-import type { Adapter, BaseAdapterProps } from "../../../types";
+import { readFileSync } from "node:fs";
+import type { BaseAdapterProps, SyncAdapter } from "../../../types";
 import { filteredData } from "../../utils";
-import { readFile } from "node:fs/promises";
 import YAML from "yaml";
 
 export type YamlAdapterProps = BaseAdapterProps & {
@@ -9,12 +9,12 @@ export type YamlAdapterProps = BaseAdapterProps & {
 
 const ADAPTER_NAME = "yaml adapter";
 
-export const yamlAdapter = ({ path, regex, silent }: YamlAdapterProps): Adapter => {
+export const yamlAdapter = ({ path, regex, silent }: YamlAdapterProps): SyncAdapter => {
   return {
     name: ADAPTER_NAME,
-    read: async () => {
+    read: () => {
       try {
-        const data = await readFile(path, "utf-8");
+        const data = readFileSync(path, "utf-8");
 
         const parsedData = YAML.parse(data) || {};
 

--- a/src/lib/config-sync.ts
+++ b/src/lib/config-sync.ts
@@ -8,9 +8,7 @@ import type {
   SyncConfig,
 } from "../types";
 import { safeParse } from "zod/v4/core";
-import { getSafeProcessEnv } from "./utils/get-safe-process-env";
-import { deepMerge } from "./utils";
-import { processAdapterData } from "./config";
+import { deepMerge, getSafeProcessEnv, processAdapterData } from "./utils";
 
 /**
  * Synchronously load config from adapters.
@@ -63,6 +61,9 @@ export const loadConfigSync = <T extends SchemaConfig>(
   return result.data as InferredDataConfig<T>;
 };
 
+/**
+ * Load data from adapters synchronously.
+ */
 const getDataFromAdaptersSync = (
   adapters: Array<SyncAdapter>,
   logger: Logger,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,12 +8,11 @@ import type {
   SchemaConfig,
   SyncAdapter,
 } from "../types";
-import { applyKeyMatching, deepMerge, getSchemaShape } from "./utils";
+import { deepMerge, getSafeProcessEnv, processAdapterData } from "./utils";
 import { safeParseAsync } from "zod/v4/core";
-import { getSafeProcessEnv } from "./utils/get-safe-process-env";
 
 /**
- * Load config from adapters.
+ * Load config from adapters asynchronously.
  *
  * - If no adapters are provided, we will read from process.env.
  * - If multiple adapters are provided, we will deep merge the data from all adapters, with the last adapter taking precedence.
@@ -63,6 +62,10 @@ export const loadConfig = async <T extends SchemaConfig>(
   return result.data as InferredDataConfig<T>;
 };
 
+
+/**
+ * Load data from adapters asynchronously.
+ */
 const getDataFromAdapters = async (
   adapters: Array<Adapter | SyncAdapter>,
   logger: Logger,
@@ -99,20 +102,3 @@ const getDataFromAdapters = async (
   return deepMerge({}, ...promiseResult);
 };
 
-export const processAdapterData = (
-  data: Record<string, unknown>,
-  schema: SchemaConfig,
-  keyMatching: KeyMatching,
-): Record<string, unknown> => {
-  if (keyMatching === "strict") {
-    return data;
-  }
-
-  const shape = getSchemaShape(schema);
-
-  if (!shape) {
-    return data;
-  }
-
-  return applyKeyMatching(data, shape, keyMatching);
-};

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -2,3 +2,5 @@ export * from "./deep-merge";
 export * from "./filtered-data";
 export * from "./is-mergeable-object";
 export * from "./key-matchers";
+export * from "./process-adapter-data";
+export * from "./get-safe-process-env";

--- a/src/lib/utils/process-adapter-data.ts
+++ b/src/lib/utils/process-adapter-data.ts
@@ -1,0 +1,20 @@
+import type { KeyMatching, SchemaConfig } from "../../types";
+import { applyKeyMatching, getSchemaShape } from ".";
+
+export const processAdapterData = (
+  data: Record<string, unknown>,
+  schema: SchemaConfig,
+  keyMatching: KeyMatching,
+): Record<string, unknown> => {
+  if (keyMatching === "strict") {
+    return data;
+  }
+
+  const shape = getSchemaShape(schema);
+
+  if (!shape) {
+    return data;
+  }
+
+  return applyKeyMatching(data, shape, keyMatching);
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,18 +36,12 @@ export type InferredErrorConfig<S extends SchemaConfig> = S extends z3.ZodType<i
     ? z.$ZodError<U>
     : never;
 
-/**
- * Adapter type
- */
-export type Adapter<D extends SchemaConfig = SchemaConfig> = {
+type BaseAdapter = {
   /**
    * Name of the adapter
    */
   name: string;
-  /**
-   * Read the config
-   */
-  read: () => Promise<InferredDataConfig<D>>;
+
   /**
    * Whether to suppress errors
    */
@@ -55,17 +49,30 @@ export type Adapter<D extends SchemaConfig = SchemaConfig> = {
 };
 
 /**
- * Config type
+ * Adapter type
  */
-export type Config<S extends SchemaConfig = SchemaConfig> = {
+export type Adapter<D extends SchemaConfig = SchemaConfig> = BaseAdapter & {
+  /**
+   * Read the config
+   */
+  read: () => Promise<InferredDataConfig<D>>;
+};
+
+/**
+ * Synchronous adapter type
+ */
+export type SyncAdapter<D extends SchemaConfig = SchemaConfig> = BaseAdapter & {
+  /**
+   * Read the config
+   */
+  read: () => InferredDataConfig<D>;
+};
+
+export type BaseConfig<S extends SchemaConfig = SchemaConfig> = {
   /**
    * Schema to validate the config against
    */
   schema: S;
-  /**
-   * Adapters to use
-   */
-  adapters?: Adapter[] | Adapter;
   /**
    * Function to call on success
    */
@@ -82,6 +89,26 @@ export type Config<S extends SchemaConfig = SchemaConfig> = {
    * How to handle casing differences.
    */
   keyMatching?: KeyMatching;
+};
+
+/**
+ * Config type
+ */
+export type Config<S extends SchemaConfig = SchemaConfig> = BaseConfig<S> & {
+  /**
+   * Adapters to use
+   */
+  adapters?: Array<Adapter | SyncAdapter> | Adapter | SyncAdapter;
+};
+
+/**
+ * Synchronous config type
+ */
+export type SyncConfig<S extends SchemaConfig = SchemaConfig> = BaseConfig<S> & {
+  /**
+   * Adapters to use
+   */
+  adapters?: Array<SyncAdapter> | SyncAdapter;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,4 +135,7 @@ export type BaseAdapterProps = {
   silent?: boolean;
 };
 
+/**
+ * Key matching type
+ */
 export type KeyMatching = "lenient" | "strict";

--- a/tests/zod-3/callbacks.test.ts
+++ b/tests/zod-3/callbacks.test.ts
@@ -1,53 +1,105 @@
 import { loadConfig } from "@/lib/config";
-import {} from "node:fs/promises";
+import { loadConfigSync } from "@/lib/configSync";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod/v3";
 
 describe("callbacks", () => {
-  it("should call onError when schema is invalid", async () => {
-    // given
-    const schema = z.object({
-      HOST: z.string(),
-      PORT: z.number(),
+  describe("loadConfig", () => {
+    it("should call onError when schema is invalid", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.number(),
+      });
+
+      process.env = {
+        HOST: "localhost",
+        PORT: "3000",
+      };
+
+      const onError = vi.fn();
+
+      // when
+      await loadConfig({
+        schema,
+        onError,
+      });
+
+      // then
+      expect(onError).toHaveBeenCalled();
     });
+    it("should call onSuccess when schema is valid", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().regex(/^\d+$/),
+      });
 
-    process.env = {
-      HOST: "localhost",
-      PORT: "3000",
-    };
+      process.env = {
+        HOST: "localhost",
+        PORT: "3000",
+      };
 
-    const onError = vi.fn();
+      const onSuccess = vi.fn();
 
-    // when
-    await loadConfig({
-      schema,
-      onError,
+      // when
+      await loadConfig({
+        schema,
+        onSuccess,
+      });
+
+      // then
+      expect(onSuccess).toHaveBeenCalled();
     });
-
-    // then
-    expect(onError).toHaveBeenCalled();
   });
-  it("should call onSuccess when schema is valid", async () => {
-    // given
-    const schema = z.object({
-      HOST: z.string(),
-      PORT: z.string().regex(/^\d+$/),
+
+  describe("loadConfigSync", () => {
+    it("should call onError when schema is invalid", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.number(),
+      });
+
+      process.env = {
+        HOST: "localhost",
+        PORT: "3000",
+      };
+
+      const onError = vi.fn();
+
+      // when
+      loadConfigSync({
+        schema,
+        onError,
+      });
+
+      // then
+      expect(onError).toHaveBeenCalled();
     });
 
-    process.env = {
-      HOST: "localhost",
-      PORT: "3000",
-    };
+    it("should call onSuccess when schema is valid", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().regex(/^\d+$/),
+      });
 
-    const onSuccess = vi.fn();
+      process.env = {
+        HOST: "localhost",
+        PORT: "3000",
+      };
 
-    // when
-    await loadConfig({
-      schema,
-      onSuccess,
+      const onSuccess = vi.fn();
+
+      // when
+      loadConfigSync({
+        schema,
+        onSuccess,
+      });
+
+      // then
+      expect(onSuccess).toHaveBeenCalled();
     });
-
-    // then
-    expect(onSuccess).toHaveBeenCalled();
   });
 });

--- a/tests/zod-3/callbacks.test.ts
+++ b/tests/zod-3/callbacks.test.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "@/lib/config";
-import { loadConfigSync } from "@/lib/configSync";
+import { loadConfigSync } from "@/lib/config-sync";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod/v3";
 

--- a/tests/zod-3/sync-async-adapter.test.ts
+++ b/tests/zod-3/sync-async-adapter.test.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "@/lib/config";
-import { loadConfigSync } from "@/lib/configSync";
+import { loadConfigSync } from "@/lib/config-sync";
 import { describe, expect, it } from "vitest";
 import type { Adapter } from "@/types";
 import { z } from "zod/v4";
@@ -46,6 +46,42 @@ describe("custom adapter", () => {
   });
 
   describe("loadConfigSync", () => {
+    it("should return parsed data when schema is valid with both sync custom adapters", () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().regex(/^\d+$/),
+      });
+
+      const customAdapter1 = {
+        name: "custom sync adapter 1",
+        read:  () => {
+          return {
+            HOST: "custom host 1",
+            PORT: "1111",
+          };
+        },
+      };
+
+      const customAdapter2 = {
+        name: "custom sync adapter 2",
+        read: () => {
+          return {
+            HOST: "custom host 2"
+          };
+        },
+      };
+
+      // when
+      const config = loadConfigSync({
+        schema,
+        adapters: [customAdapter1, customAdapter2],
+      });
+
+      // then
+      expect(config.HOST).toBe("custom host 2");
+      expect(config.PORT).toBe("1111");
+    });
     it("should throw an error when an async adapter is provided", async () => {
       // given
       const schema = z.object({

--- a/tests/zod-3/sync-async-adapter.test.ts
+++ b/tests/zod-3/sync-async-adapter.test.ts
@@ -1,0 +1,76 @@
+import { loadConfig } from "@/lib/config";
+import { loadConfigSync } from "@/lib/configSync";
+import { describe, expect, it } from "vitest";
+import type { Adapter } from "@/types";
+import { z } from "zod/v4";
+
+describe("custom adapter", () => {
+  describe("loadConfig", () => {
+    it("should return parsed data when schema is valid with both async and sync custom adapters", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().regex(/^\d+$/),
+      });
+
+      const customAdapter1 = {
+        name: "custom async adapter 1",
+        read: async () => {
+          return {
+            HOST: "custom host 1",
+            PORT: "1111",
+          };
+        },
+      };
+
+      const customAdapter2 = {
+        name: "custom sync adapter 2",
+        read: () => {
+          return {
+            HOST: "custom host 2",
+            PORT: "2222",
+          };
+        },
+      };
+
+      // when
+      const config = await loadConfig({
+        schema,
+        adapters: [customAdapter1, customAdapter2],
+      });
+
+      // then
+      expect(config.HOST).toBe("custom host 2");
+      expect(config.PORT).toBe("2222");
+    });
+  });
+
+  describe("loadConfigSync", () => {
+    it("should throw an error when an async adapter is provided", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().regex(/^\d+$/),
+      });
+
+      const customAdapter1: Adapter = {
+        name: "custom adapter 1",
+        read: async () => {
+          return {
+            HOST: "custom host 1",
+            PORT: "1111",
+          };
+        },
+      };
+
+      expect(() =>
+        loadConfigSync({
+          schema,
+          adapters: [customAdapter1],
+        }),
+      ).toThrowError(
+        "Data returned from custom adapter 1 is a Promise. Use loadConfig instead of loadConfigSync to use asynchronous adapters.",
+      );
+    });
+  });
+});

--- a/tests/zod-4-mini/callbacks.test.ts
+++ b/tests/zod-4-mini/callbacks.test.ts
@@ -1,53 +1,105 @@
 import { loadConfig } from "@/lib/config";
-import {} from "node:fs/promises";
+import { loadConfigSync } from "@/lib/configSync";
 import { describe, expect, it, vi } from "vitest";
-import { z } from "zod/v4";
+import { z } from "zod/v4-mini";
 
 describe("callbacks", () => {
-  it("should call onError when schema is invalid", async () => {
-    // given
-    const schema = z.object({
-      HOST: z.string(),
-      PORT: z.number(),
+  describe("loadConfig", () => {
+    it("should call onError when schema is invalid", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.number(),
+      });
+
+      process.env = {
+        HOST: "localhost",
+        PORT: "3000",
+      };
+
+      const onError = vi.fn();
+
+      // when
+      await loadConfig({
+        schema,
+        onError,
+      });
+
+      // then
+      expect(onError).toHaveBeenCalled();
     });
+    it("should call onSuccess when schema is valid", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().check(z.regex(/^\d+$/)),
+      });
 
-    process.env = {
-      HOST: "localhost",
-      PORT: "3000",
-    };
+      process.env = {
+        HOST: "localhost",
+        PORT: "3000",
+      };
 
-    const onError = vi.fn();
+      const onSuccess = vi.fn();
 
-    // when
-    await loadConfig({
-      schema,
-      onError,
+      // when
+      await loadConfig({
+        schema,
+        onSuccess,
+      });
+
+      // then
+      expect(onSuccess).toHaveBeenCalled();
     });
-
-    // then
-    expect(onError).toHaveBeenCalled();
   });
-  it("should call onSuccess when schema is valid", async () => {
-    // given
-    const schema = z.object({
-      HOST: z.string(),
-      PORT: z.string().regex(/^\d+$/),
+
+  describe("loadConfigSync", () => {
+    it("should call onError when schema is invalid", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.number(),
+      });
+
+      process.env = {
+        HOST: "localhost",
+        PORT: "3000",
+      };
+
+      const onError = vi.fn();
+
+      // when
+      loadConfigSync({
+        schema,
+        onError,
+      });
+
+      // then
+      expect(onError).toHaveBeenCalled();
     });
 
-    process.env = {
-      HOST: "localhost",
-      PORT: "3000",
-    };
+    it("should call onSuccess when schema is valid", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().check(z.regex(/^\d+$/)),
+      });
 
-    const onSuccess = vi.fn();
+      process.env = {
+        HOST: "localhost",
+        PORT: "3000",
+      };
 
-    // when
-    await loadConfig({
-      schema,
-      onSuccess,
+      const onSuccess = vi.fn();
+
+      // when
+      loadConfigSync({
+        schema,
+        onSuccess,
+      });
+
+      // then
+      expect(onSuccess).toHaveBeenCalled();
     });
-
-    // then
-    expect(onSuccess).toHaveBeenCalled();
   });
 });

--- a/tests/zod-4-mini/callbacks.test.ts
+++ b/tests/zod-4-mini/callbacks.test.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "@/lib/config";
-import { loadConfigSync } from "@/lib/configSync";
+import { loadConfigSync } from "@/lib/config-sync";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod/v4-mini";
 

--- a/tests/zod-4-mini/sync-async-adapter.test.ts
+++ b/tests/zod-4-mini/sync-async-adapter.test.ts
@@ -1,0 +1,76 @@
+import { loadConfig } from "@/lib/config";
+import { loadConfigSync } from "@/lib/configSync";
+import type { Adapter } from "@/types";
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4-mini";
+
+describe("custom adapter", () => {
+  describe("loadConfig", () => {
+    it("should return parsed data when schema is valid with both async and sync custom adapters", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().check(z.regex(/^\d+$/)),
+      });
+
+      const customAdapter1 = {
+        name: "custom async adapter 1",
+        read: async () => {
+          return {
+            HOST: "custom host 1",
+            PORT: "1111",
+          };
+        },
+      };
+
+      const customAdapter2 = {
+        name: "custom sync adapter 2",
+        read: () => {
+          return {
+            HOST: "custom host 2",
+            PORT: "2222",
+          };
+        },
+      };
+
+      // when
+      const config = await loadConfig({
+        schema,
+        adapters: [customAdapter1, customAdapter2],
+      });
+
+      // then
+      expect(config.HOST).toBe("custom host 2");
+      expect(config.PORT).toBe("2222");
+    });
+  });
+
+  describe("loadConfigSync", () => {
+    it("should throw an error when an async adapter is provided", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().check(z.regex(/^\d+$/)),
+      });
+
+      const customAdapter1: Adapter = {
+        name: "custom adapter 1",
+        read: async () => {
+          return {
+            HOST: "custom host 1",
+            PORT: "1111",
+          };
+        },
+      };
+
+      expect(() =>
+        loadConfigSync({
+          schema,
+          adapters: [customAdapter1],
+        }),
+      ).toThrowError(
+        "Data returned from custom adapter 1 is a Promise. Use loadConfig instead of loadConfigSync to use asynchronous adapters.",
+      );
+    });
+  });
+});

--- a/tests/zod-4-mini/sync-async-adapter.test.ts
+++ b/tests/zod-4-mini/sync-async-adapter.test.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "@/lib/config";
-import { loadConfigSync } from "@/lib/configSync";
+import { loadConfigSync } from "@/lib/config-sync";
 import type { Adapter } from "@/types";
 import { describe, expect, it } from "vitest";
 import { z } from "zod/v4-mini";
@@ -46,6 +46,42 @@ describe("custom adapter", () => {
   });
 
   describe("loadConfigSync", () => {
+    it("should return parsed data when schema is valid with both sync custom adapters", () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string()
+      });
+
+      const customAdapter1 = {
+        name: "custom sync adapter 1",
+        read:  () => {
+          return {
+            HOST: "custom host 1",
+            PORT: "1111",
+          };
+        },
+      };
+
+      const customAdapter2 = {
+        name: "custom sync adapter 2",
+        read: () => {
+          return {
+            HOST: "custom host 2"
+          };
+        },
+      };
+
+      // when
+      const config = loadConfigSync({
+        schema,
+        adapters: [customAdapter1, customAdapter2],
+      });
+
+      // then
+      expect(config.HOST).toBe("custom host 2");
+      expect(config.PORT).toBe("1111");
+    });
     it("should throw an error when an async adapter is provided", async () => {
       // given
       const schema = z.object({

--- a/tests/zod-4/callbacks.test.ts
+++ b/tests/zod-4/callbacks.test.ts
@@ -1,53 +1,105 @@
 import { loadConfig } from "@/lib/config";
-import {} from "node:fs/promises";
+import { loadConfigSync } from "@/lib/configSync";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod/v4";
 
 describe("callbacks", () => {
-  it("should call onError when schema is invalid", async () => {
-    // given
-    const schema = z.object({
-      HOST: z.string(),
-      PORT: z.number(),
+  describe("loadConfig", () => {
+    it("should call onError when schema is invalid", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.number(),
+      });
+
+      process.env = {
+        HOST: "localhost",
+        PORT: "3000",
+      };
+
+      const onError = vi.fn();
+
+      // when
+      await loadConfig({
+        schema,
+        onError,
+      });
+
+      // then
+      expect(onError).toHaveBeenCalled();
     });
+    it("should call onSuccess when schema is valid", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().regex(/^\d+$/),
+      });
 
-    process.env = {
-      HOST: "localhost",
-      PORT: "3000",
-    };
+      process.env = {
+        HOST: "localhost",
+        PORT: "3000",
+      };
 
-    const onError = vi.fn();
+      const onSuccess = vi.fn();
 
-    // when
-    await loadConfig({
-      schema,
-      onError,
+      // when
+      await loadConfig({
+        schema,
+        onSuccess,
+      });
+
+      // then
+      expect(onSuccess).toHaveBeenCalled();
     });
-
-    // then
-    expect(onError).toHaveBeenCalled();
   });
-  it("should call onSuccess when schema is valid", async () => {
-    // given
-    const schema = z.object({
-      HOST: z.string(),
-      PORT: z.string().regex(/^\d+$/),
+
+  describe("loadConfigSync", () => {
+    it("should call onError when schema is invalid", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.number(),
+      });
+
+      process.env = {
+        HOST: "localhost",
+        PORT: "3000",
+      };
+
+      const onError = vi.fn();
+
+      // when
+      loadConfigSync({
+        schema,
+        onError,
+      });
+
+      // then
+      expect(onError).toHaveBeenCalled();
     });
 
-    process.env = {
-      HOST: "localhost",
-      PORT: "3000",
-    };
+    it("should call onSuccess when schema is valid", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().regex(/^\d+$/),
+      });
 
-    const onSuccess = vi.fn();
+      process.env = {
+        HOST: "localhost",
+        PORT: "3000",
+      };
 
-    // when
-    await loadConfig({
-      schema,
-      onSuccess,
+      const onSuccess = vi.fn();
+
+      // when
+      loadConfigSync({
+        schema,
+        onSuccess,
+      });
+
+      // then
+      expect(onSuccess).toHaveBeenCalled();
     });
-
-    // then
-    expect(onSuccess).toHaveBeenCalled();
   });
 });

--- a/tests/zod-4/callbacks.test.ts
+++ b/tests/zod-4/callbacks.test.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "@/lib/config";
-import { loadConfigSync } from "@/lib/configSync";
+import { loadConfigSync } from "@/lib/config-sync";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod/v4";
 

--- a/tests/zod-4/custom-adapter.test.ts
+++ b/tests/zod-4/custom-adapter.test.ts
@@ -1,72 +1,142 @@
 import { loadConfig } from "@/lib/config";
-import type { Adapter } from "@/types";
+import type { Adapter, SyncAdapter } from "@/types";
 import {} from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { z } from "zod/v4";
+import { loadConfigSync } from "../../src";
 
 describe("custom adapter", () => {
-  it("should return parsed data when schema is valid", async () => {
-    // given
-    const schema = z.object({
-      HOST: z.string(),
-      APP_NAME: z.string(),
+  describe("loadConfig", () => {
+    it("should return parsed data when schema is valid", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        APP_NAME: z.string(),
+      });
+
+      const customAdapter: Adapter = {
+        name: "custom adapter",
+        read: async () => {
+          return {
+            HOST: "custom host",
+            APP_NAME: "custom name",
+          };
+        },
+      };
+
+      // when
+      const config = await loadConfig({
+        schema,
+        adapters: customAdapter,
+      });
+
+      // then
+      expect(config.HOST).toBe("custom host");
+      expect(config.APP_NAME).toBe("custom name");
     });
+    it("should return parsed data when schema is valid with multiple custom adapters", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().regex(/^\d+$/),
+      });
 
-    const customAdapter: Adapter = {
-      name: "custom adapter",
-      read: async () => {
-        return {
-          HOST: "custom host",
-          APP_NAME: "custom name",
-        };
-      },
-    };
+      const customAdapter1 = {
+        name: "custom adapter 1",
+        read: async () => {
+          return {
+            HOST: "custom host 1",
+            PORT: "1111",
+          };
+        },
+      };
 
-    // when
-    const config = await loadConfig({
-      schema,
-      adapters: customAdapter,
+      const customAdapter2 = {
+        name: "custom adapter 2",
+        read: async () => {
+          return {
+            HOST: "custom host 2",
+            PORT: "2222",
+          };
+        },
+      };
+
+      // when
+      const config = await loadConfig({
+        schema,
+        adapters: [customAdapter1, customAdapter2],
+      });
+
+      // then
+      expect(config.HOST).toBe("custom host 2");
+      expect(config.PORT).toBe("2222");
     });
-
-    // then
-    expect(config.HOST).toBe("custom host");
-    expect(config.APP_NAME).toBe("custom name");
   });
-  it("should return parsed data when schema is valid with multiple custom adapters", async () => {
-    // given
-    const schema = z.object({
-      HOST: z.string(),
-      PORT: z.string().regex(/^\d+$/),
+
+  describe("loadConfigSync", () => {
+    it("should return parsed data when schema is valid", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        APP_NAME: z.string(),
+      });
+
+      const customAdapter: SyncAdapter = {
+        name: "custom adapter",
+        read: () => {
+          return {
+            HOST: "custom host",
+            APP_NAME: "custom name",
+          };
+        },
+      };
+
+      // when
+      const config = loadConfigSync({
+        schema,
+        adapters: customAdapter,
+      });
+
+      // then
+      expect(config.HOST).toBe("custom host");
+      expect(config.APP_NAME).toBe("custom name");
     });
+    it("should return parsed data when schema is valid with multiple custom adapters", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().regex(/^\d+$/),
+      });
 
-    const customAdapter1 = {
-      name: "custom adapter 1",
-      read: async () => {
-        return {
-          HOST: "custom host 1",
-          PORT: "1111",
-        };
-      },
-    };
+      const customAdapter1 = {
+        name: "custom adapter 1",
+        read: () => {
+          return {
+            HOST: "custom host 1",
+            PORT: "1111",
+          };
+        },
+      };
 
-    const customAdapter2 = {
-      name: "custom adapter 2",
-      read: async () => {
-        return {
-          HOST: "custom host 2",
-          PORT: "2222",
-        };
-      },
-    };
+      const customAdapter2 = {
+        name: "custom adapter 2",
+        read: () => {
+          return {
+            HOST: "custom host 2",
+            PORT: "2222",
+          };
+        },
+      };
 
-    // when
-    const config = await loadConfig({
-      schema,
-      adapters: [customAdapter1, customAdapter2],
+      // when
+      const config = loadConfigSync({
+        schema,
+        adapters: [customAdapter1, customAdapter2],
+      });
+
+      // then
+      expect(config.HOST).toBe("custom host 2");
+      expect(config.PORT).toBe("2222");
     });
-
-    // then
-    expect(config.HOST).toBe("custom host 2");
-    expect(config.PORT).toBe("2222");
   });
 });

--- a/tests/zod-4/custom-adapter.test.ts
+++ b/tests/zod-4/custom-adapter.test.ts
@@ -133,7 +133,7 @@ describe("custom adapter", () => {
         schema,
         adapters: [customAdapter1, customAdapter2],
       });
-
+      
       // then
       expect(config.HOST).toBe("custom host 2");
       expect(config.PORT).toBe("2222");

--- a/tests/zod-4/sync-async-adapter.test.ts
+++ b/tests/zod-4/sync-async-adapter.test.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "@/lib/config";
-import { loadConfigSync } from "@/lib/configSync";
+import { loadConfigSync } from "@/lib/config-sync";
 import type { Adapter } from "@/types";
 import { describe, expect, it } from "vitest";
 import { z } from "zod/v4";
@@ -46,6 +46,42 @@ describe("custom adapter", () => {
   });
 
   describe("loadConfigSync", () => {
+    it("should return parsed data when schema is valid with both sync custom adapters", () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().regex(/^\d+$/),
+      });
+
+      const customAdapter1 = {
+        name: "custom sync adapter 1",
+        read:  () => {
+          return {
+            HOST: "custom host 1",
+            PORT: "1111",
+          };
+        },
+      };
+
+      const customAdapter2 = {
+        name: "custom sync adapter 2",
+        read: () => {
+          return {
+            HOST: "custom host 2"
+          };
+        },
+      };
+
+      // when
+      const config = loadConfigSync({
+        schema,
+        adapters: [customAdapter1, customAdapter2],
+      });
+
+      // then
+      expect(config.HOST).toBe("custom host 2");
+      expect(config.PORT).toBe("1111");
+    });
     it("should throw an error when an async adapter is provided", async () => {
       // given
       const schema = z.object({

--- a/tests/zod-4/sync-async-adapter.test.ts
+++ b/tests/zod-4/sync-async-adapter.test.ts
@@ -1,0 +1,76 @@
+import { loadConfig } from "@/lib/config";
+import { loadConfigSync } from "@/lib/configSync";
+import type { Adapter } from "@/types";
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+
+describe("custom adapter", () => {
+  describe("loadConfig", () => {
+    it("should return parsed data when schema is valid with both async and sync custom adapters", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().regex(/^\d+$/),
+      });
+
+      const customAdapter1 = {
+        name: "custom async adapter 1",
+        read: async () => {
+          return {
+            HOST: "custom host 1",
+            PORT: "1111",
+          };
+        },
+      };
+
+      const customAdapter2 = {
+        name: "custom sync adapter 2",
+        read: () => {
+          return {
+            HOST: "custom host 2",
+            PORT: "2222",
+          };
+        },
+      };
+
+      // when
+      const config = await loadConfig({
+        schema,
+        adapters: [customAdapter1, customAdapter2],
+      });
+
+      // then
+      expect(config.HOST).toBe("custom host 2");
+      expect(config.PORT).toBe("2222");
+    });
+  });
+
+  describe("loadConfigSync", () => {
+    it("should throw an error when an async adapter is provided", async () => {
+      // given
+      const schema = z.object({
+        HOST: z.string(),
+        PORT: z.string().regex(/^\d+$/),
+      });
+
+      const customAdapter1: Adapter = {
+        name: "custom adapter 1",
+        read: async () => {
+          return {
+            HOST: "custom host 1",
+            PORT: "1111",
+          };
+        },
+      };
+
+      expect(() =>
+        loadConfigSync({
+          schema,
+          adapters: [customAdapter1],
+        }),
+      ).toThrowError(
+        "Data returned from custom adapter 1 is a Promise. Use loadConfig instead of loadConfigSync to use asynchronous adapters.",
+      );
+    });
+  });
+});

--- a/tests/zod-4/utils.test.ts
+++ b/tests/zod-4/utils.test.ts
@@ -1,5 +1,6 @@
-import { deepMerge, filterByRegex, isMergeableObject } from "../../src/lib/utils";
+import { deepMerge, filterByRegex, isMergeableObject, processAdapterData } from "../../src/lib/utils";
 import { describe, it, expect } from "vitest";
+import { z } from "zod/v4";
 
 describe("filterByRegex", () => {
   it("should return an object with keys that match the regex #1", () => {
@@ -139,3 +140,38 @@ describe("isMergeableObject", () => {
     expect(isMergeableObject(new Set())).toBe(false);
   });
 });
+
+
+describe("processAdapterData", () => {
+  it("should return the data when key matching is strict", () => {
+    const schema = z.object({
+      a: z.string(),
+    });
+
+    const data = {
+      a: "1",
+    };
+
+    const processedData = processAdapterData(data, schema, "strict");
+
+    expect(processedData).toEqual(data);
+  });
+
+  it("should return the data when key matching is lenient", () => {
+    const schema = z.object({
+      A: z.string(),
+    });
+
+    const data = {
+      a: "1",
+    };
+
+    const processedData = processAdapterData(data, schema, "lenient");
+
+    expect(processedData).toEqual({
+      A: "1",
+    });
+  });
+});
+
+


### PR DESCRIPTION
Took a shot at #32, there's some duplication due to read not being async, and not using the async safe parse methods. I converted most of the default adapters to sync adapters, except for the script and directory adapters.

If an async adapter is passed to the sync config loader it will throw an error when a promise is returned.

Resolves #32 

