### PR TITLE
fix: handle zod type wrapped in ZodDefault or ZodOptional

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -62,7 +62,6 @@ export const loadConfig = async <T extends SchemaConfig>(
   return result.data as InferredDataConfig<T>;
 };
 
-
 /**
  * Load data from adapters asynchronously.
  */
@@ -101,4 +100,3 @@ const getDataFromAdapters = async (
   // Perform deep merge of data from all adapters
   return deepMerge({}, ...promiseResult);
 };
-

--- a/src/lib/utils/key-matchers.ts
+++ b/src/lib/utils/key-matchers.ts
@@ -2,6 +2,7 @@ import {
   type AnyZodObject,
   ZodDefault,
   ZodObject,
+  ZodOptional,
   type ZodRawShape,
   type ZodTypeAny,
 } from "zod/v3";
@@ -79,12 +80,20 @@ function isZodDefault(input: unknown): input is z.$ZodDefault {
   return input instanceof z.$ZodDefault;
 }
 
+function isZodOptional(input: unknown): input is z.$ZodOptional {
+  return input instanceof z.$ZodOptional;
+}
+
 function isZodObjectV3(input: unknown): input is AnyZodObject {
   return input instanceof ZodObject;
 }
 
 function isZodDefultV3(input: unknown): input is ZodDefault<any> {
   return input instanceof ZodDefault;
+}
+
+function isZodOptionalV3(input: unknown): input is ZodOptional<any> {
+  return input instanceof ZodOptional;
 }
 
 function isZodPipeTransformObject(
@@ -104,7 +113,7 @@ function compareBy<T, R>(selector: (it: T) => R): (a: T, b: T) => boolean {
 }
 
 export function getShape(schema: z.$ZodType<unknown>): z.$ZodShape | undefined {
-  if (isZodDefault(schema)) return getShape(schema._zod.def.innerType);
+  if (isZodDefault(schema) || isZodOptional(schema)) return getShape(schema._zod.def.innerType);
   if (isZodObject(schema)) return schema._zod.def.shape;
   if (isZodPipeTransformObject(schema)) return schema._zod.def.in._zod.def.shape;
   if (isZodPipePreprocessObject(schema)) return schema._zod.def.out._zod.def.shape;
@@ -112,7 +121,7 @@ export function getShape(schema: z.$ZodType<unknown>): z.$ZodShape | undefined {
 }
 
 export function getShapeV3(schema: ZodTypeAny): ZodRawShape | undefined {
-  if (isZodDefultV3(schema)) return getShapeV3(schema._def.innerType);
+  if (isZodDefultV3(schema) || isZodOptionalV3(schema)) return getShapeV3(schema._def.innerType);
   if (isZodObjectV3(schema)) return schema.shape;
   return undefined;
 }

--- a/src/lib/utils/key-matchers.ts
+++ b/src/lib/utils/key-matchers.ts
@@ -1,4 +1,10 @@
-import { type AnyZodObject, ZodObject, type ZodRawShape, type ZodTypeAny } from "zod/v3";
+import {
+  type AnyZodObject,
+  ZodDefault,
+  ZodObject,
+  type ZodRawShape,
+  type ZodTypeAny,
+} from "zod/v3";
 import * as z from "zod/v4/core";
 import { isMergeableObject } from "@/lib/utils/is-mergeable-object";
 import type { KeyMatching, ShapeConfig } from "@/types";
@@ -69,8 +75,16 @@ function isZodObject(input: unknown): input is z.$ZodObject {
   return input instanceof z.$ZodObject;
 }
 
+function isZodDefault(input: unknown): input is z.$ZodDefault {
+  return input instanceof z.$ZodDefault;
+}
+
 function isZodObjectV3(input: unknown): input is AnyZodObject {
   return input instanceof ZodObject;
+}
+
+function isZodDefultV3(input: unknown): input is ZodDefault<any> {
+  return input instanceof ZodDefault;
 }
 
 function isZodPipeTransformObject(
@@ -90,6 +104,7 @@ function compareBy<T, R>(selector: (it: T) => R): (a: T, b: T) => boolean {
 }
 
 export function getShape(schema: z.$ZodType<unknown>): z.$ZodShape | undefined {
+  if (isZodDefault(schema)) return getShape(schema._zod.def.innerType);
   if (isZodObject(schema)) return schema._zod.def.shape;
   if (isZodPipeTransformObject(schema)) return schema._zod.def.in._zod.def.shape;
   if (isZodPipePreprocessObject(schema)) return schema._zod.def.out._zod.def.shape;
@@ -97,6 +112,7 @@ export function getShape(schema: z.$ZodType<unknown>): z.$ZodShape | undefined {
 }
 
 export function getShapeV3(schema: ZodTypeAny): ZodRawShape | undefined {
+  if (isZodDefultV3(schema)) return getShapeV3(schema._def.innerType);
   if (isZodObjectV3(schema)) return schema.shape;
   return undefined;
 }

--- a/tests/zod-3/default-adapter.test.ts
+++ b/tests/zod-3/default-adapter.test.ts
@@ -37,7 +37,7 @@ describe("default adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
       }),

--- a/tests/zod-3/dotenv-adapter.test.ts
+++ b/tests/zod-3/dotenv-adapter.test.ts
@@ -66,7 +66,7 @@ describe("dotenv adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: dotEnvAdapter({
@@ -136,7 +136,7 @@ describe("dotenv adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: dotEnvAdapter({

--- a/tests/zod-3/json-adapter.test.ts
+++ b/tests/zod-3/json-adapter.test.ts
@@ -45,7 +45,7 @@ describe("json adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: jsonAdapter({
@@ -115,7 +115,7 @@ describe("json adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: jsonAdapter({

--- a/tests/zod-3/key-matchers.test.ts
+++ b/tests/zod-3/key-matchers.test.ts
@@ -180,6 +180,48 @@ describe("applyKeyMatching", () => {
     });
   });
 
+  it("should handle key matching for zod type wrapped in a ZodOptional", () => {
+    // given
+    const schema = z.object({
+      database: z
+        .object({
+          connection: z.object({
+            host: z.string(),
+            port: z.number(),
+            username: z.string(),
+            password: z.string(),
+          }),
+        })
+        .optional(),
+    });
+
+    // database is not provided
+    const data = {
+      data_base: {
+        CONNECTION: {
+          password: "password",
+        },
+      },
+    };
+
+    // when
+    const shape = getShapeV3(schema);
+    if (!shape) {
+      throw new Error("Shape should not be undefined");
+    }
+
+    const result = applyKeyMatching(data, shape, "lenient");
+
+    // then
+    expect(result).toEqual({
+      database: {
+        connection: {
+          password: "password",
+        },
+      },
+    });
+  });
+
   it("should handle max depth to prevent circular references", () => {
     // given
     const schema = z.object({

--- a/tests/zod-3/key-matchers.test.ts
+++ b/tests/zod-3/key-matchers.test.ts
@@ -131,6 +131,55 @@ describe("applyKeyMatching", () => {
     });
   });
 
+  it("should handle key matching for zod type wrapped in a ZodDefault", () => {
+    // given
+    const schema = z.object({
+      database: z
+        .object({
+          connection: z.object({
+            host: z.string(),
+            port: z.number(),
+            username: z.string(),
+            password: z.string(),
+          }),
+        })
+        .default({
+          connection: {
+            host: "host",
+            port: 3000,
+            password: "password",
+            username: "username",
+          },
+        }),
+    });
+
+    // database is not provided
+    const data = {
+      data_base: {
+        CONNECTION: {
+          password: "password",
+        },
+      },
+    };
+
+    // when
+    const shape = getShapeV3(schema);
+    if (!shape) {
+      throw new Error("Shape should not be undefined");
+    }
+
+    const result = applyKeyMatching(data, shape, "lenient");
+
+    // then
+    expect(result).toEqual({
+      database: {
+        connection: {
+          password: "password",
+        },
+      },
+    });
+  });
+
   it("should handle max depth to prevent circular references", () => {
     // given
     const schema = z.object({

--- a/tests/zod-3/sync-async-adapter.test.ts
+++ b/tests/zod-3/sync-async-adapter.test.ts
@@ -55,7 +55,7 @@ describe("custom adapter", () => {
 
       const customAdapter1 = {
         name: "custom sync adapter 1",
-        read:  () => {
+        read: () => {
           return {
             HOST: "custom host 1",
             PORT: "1111",
@@ -67,7 +67,7 @@ describe("custom adapter", () => {
         name: "custom sync adapter 2",
         read: () => {
           return {
-            HOST: "custom host 2"
+            HOST: "custom host 2",
           };
         },
       };

--- a/tests/zod-3/toml-adapter.test.ts
+++ b/tests/zod-3/toml-adapter.test.ts
@@ -90,7 +90,7 @@ crons = ["0 0 * * *"]
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: tomlAdapter({
@@ -162,7 +162,7 @@ crons = ["0 0 * * *"]
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: tomlAdapter({

--- a/tests/zod-3/yaml-adapter.test.ts
+++ b/tests/zod-3/yaml-adapter.test.ts
@@ -46,7 +46,7 @@ describe("yaml adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: yamlAdapter({
@@ -118,7 +118,7 @@ describe("yaml adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: yamlAdapter({

--- a/tests/zod-4-mini/default-adapter.test.ts
+++ b/tests/zod-4-mini/default-adapter.test.ts
@@ -37,7 +37,7 @@ describe("default adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
       }),

--- a/tests/zod-4-mini/dotenv-adapter.test.ts
+++ b/tests/zod-4-mini/dotenv-adapter.test.ts
@@ -119,7 +119,7 @@ describe("dotenv adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: dotEnvAdapter({
@@ -189,7 +189,7 @@ describe("dotenv adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: dotEnvAdapter({

--- a/tests/zod-4-mini/json-adapter.test.ts
+++ b/tests/zod-4-mini/json-adapter.test.ts
@@ -45,7 +45,7 @@ describe("json adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: jsonAdapter({
@@ -115,7 +115,7 @@ describe("json adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: jsonAdapter({

--- a/tests/zod-4-mini/key-matchers.test.ts
+++ b/tests/zod-4-mini/key-matchers.test.ts
@@ -131,6 +131,55 @@ describe("applyKeyMatching", () => {
     });
   });
 
+  it("should handle key matching for zod type wrapped in a ZodDefault", () => {
+    // given
+    const schema = z.object({
+      database: z
+        .object({
+          connection: z.object({
+            host: z.string(),
+            port: z.number(),
+            username: z.string(),
+            password: z.string(),
+          }),
+        })
+        .default({
+          connection: {
+            host: "host",
+            port: 3000,
+            password: "password",
+            username: "username",
+          },
+        }),
+    });
+
+    // database is not provided
+    const data = {
+      data_base: {
+        CONNECTION: {
+          password: "password",
+        },
+      },
+    };
+
+    // when
+    const shape = getShape(schema);
+    if (!shape) {
+      throw new Error("Shape should not be undefined");
+    }
+
+    const result = applyKeyMatching(data, shape, "lenient");
+
+    // then
+    expect(result).toEqual({
+      database: {
+        connection: {
+          password: "password",
+        },
+      },
+    });
+  });
+
   it("should handle max depth to prevent circular references", () => {
     // given
     const schema = z.object({

--- a/tests/zod-4-mini/key-matchers.test.ts
+++ b/tests/zod-4-mini/key-matchers.test.ts
@@ -180,6 +180,48 @@ describe("applyKeyMatching", () => {
     });
   });
 
+  it("should handle key matching for zod type wrapped in a ZodOptional", () => {
+    // given
+    const schema = z.object({
+      database: z
+        .object({
+          connection: z.object({
+            host: z.string(),
+            port: z.number(),
+            username: z.string(),
+            password: z.string(),
+          }),
+        })
+        .optional(),
+    });
+
+    // database is not provided
+    const data = {
+      data_base: {
+        CONNECTION: {
+          password: "password",
+        },
+      },
+    };
+
+    // when
+    const shape = getShape(schema);
+    if (!shape) {
+      throw new Error("Shape should not be undefined");
+    }
+
+    const result = applyKeyMatching(data, shape, "lenient");
+
+    // then
+    expect(result).toEqual({
+      database: {
+        connection: {
+          password: "password",
+        },
+      },
+    });
+  });
+
   it("should handle max depth to prevent circular references", () => {
     // given
     const schema = z.object({

--- a/tests/zod-4-mini/sync-async-adapter.test.ts
+++ b/tests/zod-4-mini/sync-async-adapter.test.ts
@@ -50,12 +50,12 @@ describe("custom adapter", () => {
       // given
       const schema = z.object({
         HOST: z.string(),
-        PORT: z.string()
+        PORT: z.string(),
       });
 
       const customAdapter1 = {
         name: "custom sync adapter 1",
-        read:  () => {
+        read: () => {
           return {
             HOST: "custom host 1",
             PORT: "1111",
@@ -67,7 +67,7 @@ describe("custom adapter", () => {
         name: "custom sync adapter 2",
         read: () => {
           return {
-            HOST: "custom host 2"
+            HOST: "custom host 2",
           };
         },
       };

--- a/tests/zod-4-mini/toml-adapter.test.ts
+++ b/tests/zod-4-mini/toml-adapter.test.ts
@@ -90,7 +90,7 @@ crons = ["0 0 * * *"]
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: tomlAdapter({
@@ -162,7 +162,7 @@ crons = ["0 0 * * *"]
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: tomlAdapter({

--- a/tests/zod-4-mini/yaml-adapter.test.ts
+++ b/tests/zod-4-mini/yaml-adapter.test.ts
@@ -46,7 +46,7 @@ describe("yaml adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: yamlAdapter({
@@ -118,7 +118,7 @@ describe("yaml adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: yamlAdapter({

--- a/tests/zod-4/custom-adapter.test.ts
+++ b/tests/zod-4/custom-adapter.test.ts
@@ -133,7 +133,7 @@ describe("custom adapter", () => {
         schema,
         adapters: [customAdapter1, customAdapter2],
       });
-      
+
       // then
       expect(config.HOST).toBe("custom host 2");
       expect(config.PORT).toBe("2222");

--- a/tests/zod-4/default-adapter.test.ts
+++ b/tests/zod-4/default-adapter.test.ts
@@ -37,7 +37,7 @@ describe("default adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
       }),

--- a/tests/zod-4/dotenv-adapter.test.ts
+++ b/tests/zod-4/dotenv-adapter.test.ts
@@ -119,7 +119,7 @@ describe("dotenv adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: dotEnvAdapter({
@@ -189,7 +189,7 @@ describe("dotenv adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: dotEnvAdapter({

--- a/tests/zod-4/json-adapter.test.ts
+++ b/tests/zod-4/json-adapter.test.ts
@@ -45,7 +45,7 @@ describe("json adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: jsonAdapter({
@@ -115,7 +115,7 @@ describe("json adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: jsonAdapter({

--- a/tests/zod-4/key-matchers.test.ts
+++ b/tests/zod-4/key-matchers.test.ts
@@ -131,6 +131,55 @@ describe("applyKeyMatching", () => {
     });
   });
 
+  it("should handle key matching for zod type wrapped in a ZodDefault", () => {
+    // given
+    const schema = z.object({
+      database: z
+        .object({
+          connection: z.object({
+            host: z.string(),
+            port: z.number(),
+            username: z.string(),
+            password: z.string(),
+          }),
+        })
+        .default({
+          connection: {
+            host: "host",
+            port: 3000,
+            password: "password",
+            username: "username",
+          },
+        }),
+    });
+
+    // database is not provided
+    const data = {
+      data_base: {
+        CONNECTION: {
+          password: "password",
+        },
+      },
+    };
+
+    // when
+    const shape = getShape(schema);
+    if (!shape) {
+      throw new Error("Shape should not be undefined");
+    }
+
+    const result = applyKeyMatching(data, shape, "lenient");
+
+    // then
+    expect(result).toEqual({
+      database: {
+        connection: {
+          password: "password",
+        },
+      },
+    });
+  });
+
   it("should handle max depth to prevent circular references", () => {
     // given
     const schema = z.object({

--- a/tests/zod-4/key-matchers.test.ts
+++ b/tests/zod-4/key-matchers.test.ts
@@ -180,6 +180,48 @@ describe("applyKeyMatching", () => {
     });
   });
 
+  it("should handle key matching for zod type wrapped in a ZodOptional", () => {
+    // given
+    const schema = z.object({
+      database: z
+        .object({
+          connection: z.object({
+            host: z.string(),
+            port: z.number(),
+            username: z.string(),
+            password: z.string(),
+          }),
+        })
+        .optional(),
+    });
+
+    // database is not provided
+    const data = {
+      data_base: {
+        CONNECTION: {
+          password: "password",
+        },
+      },
+    };
+
+    // when
+    const shape = getShape(schema);
+    if (!shape) {
+      throw new Error("Shape should not be undefined");
+    }
+
+    const result = applyKeyMatching(data, shape, "lenient");
+
+    // then
+    expect(result).toEqual({
+      database: {
+        connection: {
+          password: "password",
+        },
+      },
+    });
+  });
+
   it("should handle max depth to prevent circular references", () => {
     // given
     const schema = z.object({

--- a/tests/zod-4/multiple-adapters.test.ts
+++ b/tests/zod-4/multiple-adapters.test.ts
@@ -130,11 +130,9 @@ describe("multiple adapters", () => {
       APP_ID: z.string(),
     });
 
-
     const customAsyncAdapter: Adapter = {
       name: "custom adapter",
       read: async () => {
-
         await new Promise((resolve) => setTimeout(resolve, 100));
 
         return {
@@ -145,8 +143,6 @@ describe("multiple adapters", () => {
         };
       },
     };
-
-
 
     // when
     const config = await loadConfig({
@@ -159,7 +155,6 @@ describe("multiple adapters", () => {
       ],
     });
 
-    
     // then
     expect(config.HOST).toBe("localhost");
     expect(config.PORT).toBe("3000");

--- a/tests/zod-4/sync-async-adapter.test.ts
+++ b/tests/zod-4/sync-async-adapter.test.ts
@@ -55,7 +55,7 @@ describe("custom adapter", () => {
 
       const customAdapter1 = {
         name: "custom sync adapter 1",
-        read:  () => {
+        read: () => {
           return {
             HOST: "custom host 1",
             PORT: "1111",
@@ -67,7 +67,7 @@ describe("custom adapter", () => {
         name: "custom sync adapter 2",
         read: () => {
           return {
-            HOST: "custom host 2"
+            HOST: "custom host 2",
           };
         },
       };

--- a/tests/zod-4/toml-adapter.test.ts
+++ b/tests/zod-4/toml-adapter.test.ts
@@ -90,7 +90,7 @@ crons = ["0 0 * * *"]
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: tomlAdapter({
@@ -162,7 +162,7 @@ crons = ["0 0 * * *"]
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: tomlAdapter({

--- a/tests/zod-4/utils.test.ts
+++ b/tests/zod-4/utils.test.ts
@@ -1,4 +1,9 @@
-import { deepMerge, filterByRegex, isMergeableObject, processAdapterData } from "../../src/lib/utils";
+import {
+  deepMerge,
+  filterByRegex,
+  isMergeableObject,
+  processAdapterData,
+} from "../../src/lib/utils";
 import { describe, it, expect } from "vitest";
 import { z } from "zod/v4";
 
@@ -141,7 +146,6 @@ describe("isMergeableObject", () => {
   });
 });
 
-
 describe("processAdapterData", () => {
   it("should return the data when key matching is strict", () => {
     const schema = z.object({
@@ -173,5 +177,3 @@ describe("processAdapterData", () => {
     });
   });
 });
-
-

--- a/tests/zod-4/yaml-adapter.test.ts
+++ b/tests/zod-4/yaml-adapter.test.ts
@@ -46,7 +46,7 @@ describe("yaml adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: yamlAdapter({
@@ -118,7 +118,7 @@ describe("yaml adapter", () => {
 
     // when
     // then
-    expect(
+    await expect(
       loadConfig({
         schema,
         adapters: yamlAdapter({


### PR DESCRIPTION
Using `.default()` or `.optional()` on a zod object would lead to issues for nested types. This correctly takes this into account for key matching.

Also:
- ran format and lint (separate commit)
- added `await` to all async expects (separate commit, got warnings when removing `--silent` from tests)